### PR TITLE
feat: add agent-replicas and secretToken to config

### DIFF
--- a/cmd/apmsoak/main.go
+++ b/cmd/apmsoak/main.go
@@ -15,8 +15,6 @@ import (
 	"go.elastic.co/ecszap"
 	"go.uber.org/zap"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/elastic/apm-perf/soaktest"
 )
 
@@ -26,25 +24,15 @@ func main() {
 	logger := zap.New(core, zap.AddCaller())
 
 	flag.Parse()
-	f, err := os.ReadFile(soaktest.SoakConfig.ScenariosPath)
-	if err != nil {
-		logger.Fatal("failed to read scenarios.yml", zap.Error(err))
-	}
-
-	var y soaktest.Scenarios
-	if err := yaml.Unmarshal(f, &y); err != nil {
-		logger.Fatal("failed to unmarshal scenarios", zap.Error(err))
-	}
-	scenarioConfigs := y.Scenarios[soaktest.SoakConfig.Scenario]
-	if scenarioConfigs == nil {
-		logger.Fatal("unknown scenario "+soaktest.SoakConfig.Scenario, zap.Error(err))
-	}
-
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	logger.Info("running scenario `" + soaktest.SoakConfig.Scenario + "`...")
-	if err := soaktest.Run(ctx, scenarioConfigs); err != nil {
+	runner, err := soaktest.NewRunner(soaktest.SoakConfig.ScenariosPath, soaktest.SoakConfig.Scenario, logger)
+	if err != nil {
+		logger.Fatal("Fail to initialize runner", zap.Error(err))
+	}
+
+	if err := runner.Run(ctx); err != nil {
 		if !errors.Is(err, context.Canceled) {
 			logger.Fatal("runner exited with error", zap.Error(err))
 		}

--- a/cmd/apmsoak/scenarios.yml
+++ b/cmd/apmsoak/scenarios.yml
@@ -1,17 +1,30 @@
 scenarios:
   steady:
-      - project_id: project_1
-        event_rate: 2000/1s
+    - project_id: project_1
+      event_rate: 2000/1s
   bursty:
-      - project_id: project_1
-        api_key: ""
-        event_rate: 60000/30s
+    - project_id: project_1
+      api_key: ""
+      event_rate: 60000/30s
   fairness:
-      - project_id: project_1
-        api_key: ""
-        rewrite_transaction_names: true
-        rewrite_span_names: true
-        event_rate: 10000/s
-      - project_id: project_2
-        api_key: ""
-        event_rate: 100/s
+    - project_id: project_1
+      api_key: ""
+      rewrite_transaction_names: true
+      rewrite_span_names: true
+      event_rate: 10000/s
+    - project_id: project_2
+      api_key: ""
+      event_rate: 100/s
+  apm-server:
+    - event_rate: 10000/1s
+      agent_name: go
+      agents-replicas: 3
+    - event_rate: 10000/1s
+      agent_name: nodejs
+      agents-replicas: 3
+    - event_rate: 10000/1s
+      agent_name: python
+      agents-replicas: 3
+    - event_rate: 10000/1s
+      agent_name: ruby
+      agents-replicas: 3

--- a/loadgen/eventhandler/handler.go
+++ b/loadgen/eventhandler/handler.go
@@ -270,6 +270,8 @@ func (h *Handler) SendBatchesInLoop(ctx context.Context) error {
 			if _, err := h.sendBatches(ctx, &s); err != nil {
 				return err
 			}
+			// safeguard `s.sent` so that it doesn't exceed math.MaxInt
+			// but keep the remainder so the next batches know where to start
 			if s.burst > 0 {
 				s.sent = s.sent % s.burst
 			}
@@ -316,11 +318,6 @@ func (h *Handler) sendBatch(
 		if s.burst > 0 {
 			mod := s.sent % s.burst
 			if mod == 0 {
-				// Safeguard `s.sent` so that it doesn't exceed math.MaxInt
-				// It is safe to reset s.sent 0 here as it is the beginning of the new interval
-				// and we are interested in the number of events sent for the duration
-				fmt.Println("s.totalSent: ", s.totalSent)
-				// s.sent = 0
 				// We're starting a new iteration, so wait to send a burst.
 				if err := h.config.Limiter.WaitN(ctx, s.burst); err != nil {
 					return err
@@ -348,7 +345,6 @@ func (h *Handler) sendBatch(
 		}
 		s.w.Reset()
 		s.sent += n
-		s.totalSent += n
 		events = events[n:]
 	}
 	return nil
@@ -572,10 +568,9 @@ func randomizeASCII(out *bytes.Buffer, in string, randomBits uint64) {
 }
 
 type state struct {
-	w         *pooledWriter
-	burst     int
-	sent      int
-	totalSent int
+	w     *pooledWriter
+	burst int
+	sent  int
 }
 
 type pooledWriter struct {

--- a/soaktest/config.go
+++ b/soaktest/config.go
@@ -15,6 +15,7 @@ var SoakConfig struct {
 	Scenario      string
 	ScenariosPath string
 	ServerURL     string
+	SecretToken   string
 	ApiKeys       map[string]string
 	BypassProxy   bool
 }
@@ -23,6 +24,7 @@ func init() {
 	flag.StringVar(&SoakConfig.Scenario, "scenario", "steady", "Specify which scenario to use")
 	flag.StringVar(&SoakConfig.ScenariosPath, "f", "./scenarios.yml", "Path to scenarios file")
 	flag.StringVar(&SoakConfig.ServerURL, "server", "", "Ingest service URL (default http://127.0.0.1:8200), if specify <project_id>, it will be replaced with the project_id provided by the config, (https://<project_id>.apm.elastic.cloud)")
+	flag.StringVar(&SoakConfig.SecretToken, "secret-token", "", "secret token for APM Server. Managed intake service doesn't support secret token")
 	flag.Func("api-keys", "API keys by projectID for apm managed service",
 		func(s string) error {
 			SoakConfig.ApiKeys = make(map[string]string)
@@ -47,8 +49,9 @@ func setFlagsFromEnv() {
 	// value[0] is environment key
 	// value[1] is default value
 	flagEnvMap := map[string][]string{
-		"server":   {"ELASTIC_APM_SERVER_URL", "http://127.0.0.1:8200"},
-		"api-keys": {"ELASTIC_APM_API_KEYS", ""},
+		"server":       {"ELASTIC_APM_SERVER_URL", "http://127.0.0.1:8200"},
+		"secret-token": {"ELASTIC_APM_SECRET_TOKEN", ""},
+		"api-keys":     {"ELASTIC_APM_API_KEYS", ""},
 	}
 
 	for k, v := range flagEnvMap {

--- a/soaktest/scenario.go
+++ b/soaktest/scenario.go
@@ -13,6 +13,7 @@ type ScenarioConfig struct {
 	ServerURL                 string            `yaml:"server"`
 	APIKey                    string            `yaml:"api_key"`
 	AgentName                 string            `yaml:"agent_name"`
+	AgentsReplicas            int               `yaml:"agent_replicas"`
 	EventRate                 string            `yaml:"event_rate"`
 	RewriteIDs                bool              `yaml:"rewrite_ids"`
 	RewriteTimestamps         bool              `yaml:"rewrite_timestamps"`


### PR DESCRIPTION
Added missing `agent-replicas` and secretToken config that is used by APM Server.

Also, 
- `apm-server` scenario is added in the YAML file just to share the configuration of the current apm-server soak testing. This later can be removed, as it's more to share the information
- When copied over the `loadgen`, I didn't realised I copied the wrong version of loadgen, so I copied it again from the main branch 😮‍💨  