### PR TITLE
Added dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+cmd/apmsoak/apmsoak

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.19.9-alpine as builder
+WORKDIR /src
+COPY . . 
+RUN cd cmd/apmsoak \
+  && go mod download \
+  && go build
+
+FROM alpine:3.14.2
+WORKDIR /src
+COPY --from=builder /src/cmd/apmsoak .
+COPY ./loadgen/events ./events
+ENTRYPOINT ["/src/apmsoak"]


### PR DESCRIPTION
Just a simple dockerfile with `apmsoak` entrypoint.

To try it:
```
docker build -t apmsoak .
docker run apmsoak [apmsoak flags]
```

Also removed accidentally added `apmsoak` binary hence it closes #6 