### PR TITLE
Remove extra comma in rewritten json

### DIFF
--- a/loadgen/eventhandler/handler.go
+++ b/loadgen/eventhandler/handler.go
@@ -478,8 +478,11 @@ func (h *Handler) writeEvents(w *pooledWriter, b batch, baseTimestamp time.Time,
 
 func rewriteJSONObject(w *pooledWriter, object gjson.Result, f func(key, value gjson.Result) bool) {
 	w.rewriteBuf.RawByte('{')
+	first := true
 	object.ForEach(func(key, value gjson.Result) bool {
-		if key.Index > 1 {
+		if first {
+			first = false
+		} else {
 			w.rewriteBuf.RawByte(',')
 		}
 		w.rewriteBuf.RawString(key.Raw)

--- a/loadgen/eventhandler/handler_test.go
+++ b/loadgen/eventhandler/handler_test.go
@@ -744,6 +744,27 @@ func TestHandlerSendBatchesRewriteTransactionTypes(t *testing.T) {
 	run(t, true)
 }
 
+func TestHandlerSendBatchesRewriteAndJSONDecode(t *testing.T) {
+	handler, srv := newHandler(t,
+		withStorage(os.DirFS("../events")),
+		withRewriteTransactionTypes(true),
+		withRand(rand.New(rand.NewSource(123456))), // known seed
+	)
+	_, err := handler.SendBatches(context.Background())
+	assert.NoError(t, err)
+
+	d := json.NewDecoder(bytes.NewReader(srv.got.Bytes()))
+	type object map[string]struct{}
+	for {
+		var object object
+		err := d.Decode(&object)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+	}
+}
+
 func TestHandlerInLoop(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		h, srv := newHandler(t)


### PR DESCRIPTION
Fix a bug in rewriting where JSON contains `{,` e.g.
```
{"span":{,"duration":3.421459,"id":"30584d3ae9db5d35","name":"DNS opbeans-ruby"
```

Error message during run:
```
{"log.level":"fatal","@timestamp":"2023-06-05T18:49:38.481+0100","log.origin":{"file.name":"apmsoak/main.go","file.line":37},"message":"runner exited with error","error":{"message":"unexpected apm server response 400: {\"accepted\":0,\"errors\":[{\"message\":\"decode error: data read error: v2.spanRoot.Span: v2.span.ReadString: expects \\\" or n,\",\"document\":\"{\\\"span\\\":{,\\\"duration\\\":3.421459,\\\"id\\\":\\\"19184d65e276cf83\\\",\\\"name\\\":\\\"DNS opbeans-ruby\\\",\\\"timestamp\\\":\\\"2023-06-05T17:49:38.490169659Z\\\",\\\"trace_id\\\":\\\"6a9e11ae87f065a5debababbd5f294ea\\\",\\\"type\\\":\\\"exter
```