### PR TITLE
feat: install ca-certificates and basic stuff

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -37,6 +37,18 @@ LABEL \
 # Switch workdir
 WORKDIR /opt/apm-perf
 
+# Add minimal stuff
+RUN \
+  apt-get update > /dev/null \
+  && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends \
+    "apt-utils=*" \
+    "ca-certificates=*" \
+    "curl=*" \
+    "gnupg=*" \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
 # Copy files
 COPY --from=builder /opt/apm-perf/dist/apmsoak /usr/bin/apmsoak
 COPY ./internal/loadgen/events ./events


### PR DESCRIPTION
## What is the change being made?

* Install ca-certificates packages
* Update OS dependencies
* Install basic stuff

## Why is the change being made?

* `apmsoak` isn't able to contact an Elastic Cloud Service.

```ndjson
{"log.level":"fatal","@timestamp":"2023-08-17T08:51:41.001Z","log.origin":{"file.name":"apmsoak/run.go","file.line":71},"message":"runner exited with error","error":{"message":"Post \"https://<REDACTED>/intake/v2/events\": tls: failed to verify certificate: x509: certificate signed by unknown authority"},"ecs.version":"1.6.0"}
```

## How has this been tested?

* `make package`