### PR TITLE
Build apm-perf image with apmbench

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -49,9 +49,13 @@ RUN \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-# Copy files
+# Copy files for apmsoak
 COPY --from=builder /opt/apm-perf/dist/apmsoak /usr/bin/apmsoak
 COPY ./internal/loadgen/events ./events
 COPY ./cmd/apmsoak/scenarios.yml /opt/apm-perf/scenarios.yml
 
+# Copy files for apmbench
+COPY --from=builder /opt/apm-perf/dist/apmbench /usr/bin/apmbench
+
+# Default to apmsoak, override to use apmbench
 CMD [ "/usr/bin/apmsoak" ]

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ build: LDFLAGS+=-X 'github.com/elastic/apm-perf/internal/version.buildTime=$(CUR
 build:
 	mkdir -p $(DIST_DIR)
 	go build -ldflags "$(LDFLAGS)" -o $(DIST_DIR)/apmsoak cmd/apmsoak/*.go
+	go build -ldflags "$(LDFLAGS)" -o $(DIST_DIR)/apmbench cmd/apmbench/*.go
 
 .PHONY: test
 test: go.mod


### PR DESCRIPTION
Builds a single image `apm-perf` with 2 binaries `apmsoak` and `apmbench`. By default, the container uses `apmsoak` command, to use `apmbench`, the user needs to override the command.