### PR TITLE
No publish docker image on main

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -3,9 +3,6 @@
 name: publish-docker-images
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main


### PR DESCRIPTION
Pull requests from source repositories outside elastic will not have access to the vault and the job will always fail. Example: https://github.com/elastic/apm-perf/actions/runs/5996469773/job/16261052191?pr=24