### PR TITLE
Handle resource attributes for otelcollector

### DIFF
--- a/cmd/apmbench/run.go
+++ b/cmd/apmbench/run.go
@@ -86,7 +86,7 @@ func Run(
 				fmt.Printf("--- FAIL: %s\n", name)
 				return fmt.Errorf("benchmark %q failed", name)
 			}
-			fmt.Printf("%-*s\t%s\t%s\n", maxLen, name, result.benchResult, result.benchResult.MemString())
+			fmt.Printf("%-*s\t%s\n", maxLen, name, result.benchResult)
 		}
 	}
 	return nil

--- a/internal/otelcollector/exporter/inmemexporter/exporter.go
+++ b/internal/otelcollector/exporter/inmemexporter/exporter.go
@@ -32,12 +32,12 @@ func new(cfg Config, store *Store, logger *zap.Logger) *inMemExporter {
 }
 
 func (e *inMemExporter) consumeMetrics(_ context.Context, ld pmetric.Metrics) error {
-	e.logger.Info("received metrics", zap.Int("count", ld.MetricCount()))
+	e.logger.Debug("received metrics", zap.Int("count", ld.MetricCount()))
 	e.store.Add(ld)
 	return nil
 }
 
 func (e *inMemExporter) consumeTraces(_ context.Context, ld ptrace.Traces) error {
-	e.logger.Info("received traces", zap.Int("count", ld.SpanCount()))
+	e.logger.Debug("received traces", zap.Int("count", ld.SpanCount()))
 	return nil
 }


### PR DESCRIPTION
- Attributes passed as resources should also be considered while matching label values.
- Removes memory data from the bench results, these data benchmark data production and not the actual memory data. 