### PR TITLE
Always run OTEL collector and optionally continue running after benchmarks

### DIFF
--- a/cmd/apmbench/config.go
+++ b/cmd/apmbench/config.go
@@ -21,6 +21,7 @@ var cfg struct {
 	// Sorted list of agents count to be used for benchmarking
 	AgentsList          []int
 	CollectorConfigYaml string
+	ServerMode          bool
 }
 
 func init() {
@@ -58,4 +59,5 @@ func init() {
 		},
 	)
 	flag.StringVar(&cfg.CollectorConfigYaml, "collector-config-yaml", "", "configuration for otel collector")
+	flag.BoolVar(&cfg.ServerMode, "server-mode", false, "continue running otel collector post benchmark run")
 }

--- a/cmd/apmbench/config.go
+++ b/cmd/apmbench/config.go
@@ -17,7 +17,6 @@ import (
 var cfg struct {
 	Count     uint
 	Benchtime time.Duration
-	Detailed  bool
 	RunRE     *regexp.Regexp
 	// Sorted list of agents count to be used for benchmarking
 	AgentsList          []int
@@ -29,7 +28,6 @@ func init() {
 
 	flag.UintVar(&cfg.Count, "count", 1, "run benchmarks `n` times")
 	flag.DurationVar(&cfg.Benchtime, "benchtime", time.Second, "run each benchmark for duration `d`")
-	flag.BoolVar(&cfg.Detailed, "detailed", false, "Get detailed metrics recorded during benchmark")
 	flag.Func("run", "run only benchmarks matching `regexp`", func(restr string) error {
 		if restr != "" {
 			re, err := regexp.Compile(restr)

--- a/cmd/apmbench/main.go
+++ b/cmd/apmbench/main.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"flag"
 	"log"
+	"os"
+	"os/signal"
 	"sync"
 	"testing"
 	"time"
@@ -95,6 +97,13 @@ func main() {
 		Benchmark10000AggregationGroups,
 	); err != nil {
 		logger.Fatal("failed to run benchmarks", zap.Error(err))
+	}
+
+	// If server-mode is enabled then keep the otel collector running
+	if cfg.ServerMode {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt, os.Kill)
+		<-c
 	}
 }
 

--- a/cmd/apmbench/main.go
+++ b/cmd/apmbench/main.go
@@ -98,7 +98,7 @@ func main() {
 	// If server-mode is enabled then keep the otel collector running
 	if cfg.ServerMode {
 		c := make(chan os.Signal, 1)
-		signal.Notify(c, os.Interrupt, os.Kill)
+		signal.Notify(c, os.Interrupt)
 		<-c
 	}
 }


### PR DESCRIPTION
PR implements the following improvements to the OTEL collector (with commit IDs for ease in review):

- Removes the unused `-detailed` flag (95a338f8f0c12088daff2e6db2c51276e2c640af): `-detailed` flag was used in `apm-server`'s bench test to print the detailed metric. In apm-perf/apmbench we print this by default.
- Always run the OTEL collector (5cf0a7d0440ce6467f2f3ba2c8aa24936aad86ff): before this PR, OTEL collector was run only when collector config were provided. These config specify which metric to store and without the config there was no point in running the collector. With this PR, we run the collector always in preparation for allowing another pipeline to ship all data to a persistent layer instead of only keeping the data in-memory.
- Allow apmbench to continue running otel collector (50c8a8304a018ca8a5924628626c81feafb934f4): Introduces a flag `-server-mode` to indicate that collector can be kept running even after benchmark has finished. This also plays into adding a persistent pipeline in future.