### PR TITLE
OTEL collector improvements

### DIFF
--- a/cmd/apmbench/run.go
+++ b/cmd/apmbench/run.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"go.elastic.co/apm/v2/stacktrace"
 	"golang.org/x/time/rate"
@@ -87,6 +88,13 @@ func Run(
 				return fmt.Errorf("benchmark %q failed", name)
 			}
 			fmt.Printf("%-*s\t%s\n", maxLen, name, result.benchResult)
+			// Sleep to allow any remaining data to be consumed by the pipelines
+			// so that they don't pollute the result of the next benchmark run.
+			//
+			// TODO (lahsivjar): Make this deterministic by introducing cleanup
+			// metrics. We can watch the cleanup metrics to reach to a specified
+			// threshold and then run the next benchmark.
+			time.Sleep(time.Minute)
 		}
 	}
 	return nil

--- a/internal/otelcollector/exporter/inmemexporter/store.go
+++ b/internal/otelcollector/exporter/inmemexporter/store.go
@@ -246,21 +246,24 @@ func (s *Store) mergeNumberDataPoints(
 			case Sum:
 				to.SetDoubleValue(to.DoubleValue() + doubleValue(dp))
 			case Rate:
-				to.SetDoubleValue(to.DoubleValue() + doubleValue(dp))
-				// We will use to#StartTimestamp and to#Timestamp fields to
-				// cache the lowest and the highest timestamps. This will be
-				// used at query time to calculate rate.
-				if to.StartTimestamp() == 0 {
-					// If the data point has a start timestamp then use that
-					// as the start timestamp, else use the end timestamp.
-					if dp.StartTimestamp() != 0 {
-						to.SetStartTimestamp(dp.StartTimestamp())
-					} else {
-						to.SetStartTimestamp(dp.Timestamp())
+				val := doubleValue(dp)
+				if val != 0 {
+					to.SetDoubleValue(to.DoubleValue() + val)
+					// We will use to#StartTimestamp and to#Timestamp fields to
+					// cache the lowest and the highest timestamps. This will be
+					// used at query time to calculate rate.
+					if to.StartTimestamp() == 0 {
+						// If the data point has a start timestamp then use that
+						// as the start timestamp, else use the end timestamp.
+						if dp.StartTimestamp() != 0 {
+							to.SetStartTimestamp(dp.StartTimestamp())
+						} else {
+							to.SetStartTimestamp(dp.Timestamp())
+						}
 					}
-				}
-				if to.Timestamp() < dp.Timestamp() {
-					to.SetTimestamp(dp.Timestamp())
+					if to.Timestamp() < dp.Timestamp() {
+						to.SetTimestamp(dp.Timestamp())
+					}
 				}
 			}
 		}


### PR DESCRIPTION
- Sleeps at the end of benchmark to give some time for the MIS pipelines to finish consuming any remaining entries in the queue.
- Calculates rate only for non-zero values. This would mean that the reported rate values would not include any leading or trailing series of zeroes.

I am unsure if they are the best improvements, let me know if they seem like a bad idea.