### PR TITLE
Fix empty api-keys option handling

### DIFF
--- a/cmd/apmsoak/run.go
+++ b/cmd/apmsoak/run.go
@@ -28,13 +28,15 @@ type RunOptions struct {
 
 func (opts *RunOptions) toRunnerConfig() (*soaktest.RunnerConfig, error) {
 	apiKeys := make(map[string]string)
-	pairs := strings.Split(opts.APIKeys, ",")
-	for _, pair := range pairs {
-		kv := strings.Split(pair, ":")
-		if len(kv) != 2 {
-			return nil, errors.New("invalid api keys provided. example: project_id:my_api_key")
+	if opts.APIKeys != "" {
+		pairs := strings.Split(opts.APIKeys, ",")
+		for _, pair := range pairs {
+			kv := strings.Split(pair, ":")
+			if len(kv) != 2 {
+				return nil, errors.New("invalid api keys provided. example: project_id:my_api_key")
+			}
+			apiKeys[kv[0]] = kv[1]
 		}
-		apiKeys[kv[0]] = kv[1]
 	}
 	return &soaktest.RunnerConfig{
 		Scenario:      opts.Scenario,


### PR DESCRIPTION
As strings.split("", ",") returns []string{""}, an empty api-keys option will cause apmsoak to throw "invalid api keys provided", effectively making api-keys a required option. Fix the handling to ignore empty api-keys.
