### PR TITLE
apmsoak,apmbench: ensure event handler logger is set

### DIFF
--- a/cmd/apmbench/bench.go
+++ b/cmd/apmbench/bench.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.uber.org/zap"
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -197,6 +198,7 @@ func newOTLPExporter(tb testing.TB) *otlptrace.Exporter {
 
 func newEventHandler(tb testing.TB, p string, l *rate.Limiter) *eventhandler.Handler {
 	h, err := loadgen.NewEventHandler(loadgen.EventHandlerParams{
+		Logger:            zap.NewNop(),
 		Path:              p,
 		Limiter:           l,
 		URL:               loadgencfg.Config.ServerURL.String(),

--- a/internal/loadgen/eventhandler.go
+++ b/internal/loadgen/eventhandler.go
@@ -7,6 +7,7 @@ package loadgen
 
 import (
 	"embed"
+	"fmt"
 	"math/rand"
 	"path/filepath"
 
@@ -75,6 +76,9 @@ func (e EventHandlerParams) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // NewEventHandler creates a eventhandler which loads the files matching the
 // passed regex.
 func NewEventHandler(p EventHandlerParams) (*eventhandler.Handler, error) {
+	if p.Logger == nil {
+		return nil, fmt.Errorf("nil logger in params")
+	}
 	// We call the HTTPTransport constructor to avoid copying all the config
 	// parsing that creates the `*http.Client`.
 	t, err := transport.NewHTTPTransport(transport.HTTPTransportOptions{})

--- a/internal/soaktest/runner.go
+++ b/internal/soaktest/runner.go
@@ -102,6 +102,7 @@ func runAgent(ctx context.Context, runner *Runner, config ScenarioConfig, rng *r
 	params.Rand = rng
 	runner.logger.Debug("computed load generation parameters", zap.Object("params", params))
 
+	params.Logger = runner.logger
 	handler, err := loadgen.NewEventHandler(params)
 	if err != nil {
 		return err


### PR DESCRIPTION
Ensure the newly added `eventhandler.Handler` logger is properly set everywhere.
