### PR TITLE
transport: log V2 responses based on outcome

### DIFF
--- a/internal/loadgen/eventhandler/transport.go
+++ b/internal/loadgen/eventhandler/transport.go
@@ -75,6 +75,9 @@ func (t *Transport) sendEvents(req *http.Request, r io.Reader, ignoreErrs bool) 
 }
 
 func logResponseOutcome(logger *zap.Logger, res *http.Response) {
+	if res == nil {
+		return
+	}
 	var body bytes.Buffer
 	if _, err := body.ReadFrom(res.Body); err != nil {
 		logger.Error("cannot read body", zap.Error(err))

--- a/internal/loadgen/eventhandler/transport_test.go
+++ b/internal/loadgen/eventhandler/transport_test.go
@@ -1,0 +1,71 @@
+package eventhandler
+
+import (
+	"bytes"
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/klauspost/compress/zlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestTransport_SendEventV2Logs(t *testing.T) {
+	s := `{"metadata":{"system":{"architecture":"arm64","hostname":"3ff988a6070f","platform":"linux"},"process":{"pid":1,"argv":["/opbeans-go","-log-json","-log-level=debug","-listen=:3000","-frontend=/opbeans-frontend","-db=postgres:","-cache=redis://redis:6379"],"ppid":0,"title":"opbeans-go"},"service":{"agent":{"name":"go","version":"2.0.0"},"environment":"production","language":{"name":"go","version":"go1.17.7"},"name":"opbeans-go","runtime":{"name":"gc","version":"go1.17.7"},"version":"None"}}}`
+	var w bytes.Buffer
+	_, err := zlib.NewWriter(&w).Write([]byte(s))
+	require.NoError(t, err)
+
+	ms := &mockServer{got: &bytes.Buffer{}}
+	srv := httptest.NewServer(ms)
+	defer srv.Close()
+
+	t.Run("always log status code in debug", func(t *testing.T) {
+		core, logs := observer.New(zap.DebugLevel)
+		err = NewTransport(zap.New(core), srv.Client(), srv.URL, "", "", nil).
+			SendV2Events(context.Background(), &w, false)
+
+		assert.NoError(t, err)
+		assert.True(t, logs.FilterFieldKey("status_code").Len() == 1)
+		assert.True(t, logs.FilterMessageSnippet("request completed").Len() == 1)
+	})
+
+	t.Run("log error if status code is 400 without ignoreErrors", func(t *testing.T) {
+		testBadRequestWithIgnoreErrors(t, srv, false, zap.ErrorLevel, assert.Error)
+	})
+
+	t.Run("log error if status code is 400 with ignoreErrors", func(t *testing.T) {
+		testBadRequestWithIgnoreErrors(t, srv, true, zap.ErrorLevel, assert.NoError)
+	})
+
+}
+
+func testBadRequestWithIgnoreErrors(
+	t *testing.T,
+	srv *httptest.Server,
+	ignoreErrors bool,
+	logLevel zapcore.Level,
+	errorCheck assert.ErrorAssertionFunc) {
+	t.Helper()
+
+	core, logs := observer.New(logLevel)
+	err := NewTransport(zap.New(core), srv.Client(), srv.URL, "", "", nil).
+		// Always make the call fail due to HTTP 400, because the body is not compressed
+		SendV2Events(context.Background(), bytes.NewBufferString("foo"), ignoreErrors)
+
+	errorCheck(t, err)
+	var (
+		loggedStatusCode any
+		ok               bool
+	)
+	assert.NotPanics(t, func() {
+		loggedStatusCode, ok = logs.FilterFieldKey("status_code").TakeAll()[0].ContextMap()["status_code"]
+	})
+	assert.True(t, ok)
+	assert.Equal(t, loggedStatusCode.(int64), int64(400))
+	assert.True(t, logs.FilterMessageSnippet("request failed").Len() == 1)
+}

--- a/internal/loadgen/eventhandler/transport_test.go
+++ b/internal/loadgen/eventhandler/transport_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package eventhandler
 
 import (


### PR DESCRIPTION
### Reason for this PR

We've been recently adding debugging information into apmsoak execution to understand quality gates failures.

### Details

Extend prior work made by @endorama in #47 and #48 to always log the response of SendV2Events on various levels.
 - successful calls -> log.DEBUG
 - error calls -> log.ERROR

in this way, even with the apmsok tool running without DEBUG level, we can still gather some insights on the errors that mat have arisen from a quality gate failure.