### PR TITLE
apmbench: add protocol to loadgen config

### DIFF
--- a/cmd/apmbench/bench.go
+++ b/cmd/apmbench/bench.go
@@ -208,6 +208,7 @@ func newEventHandler(tb testing.TB, p string, l *rate.Limiter) *eventhandler.Han
 		RewriteIDs:        loadgencfg.Config.RewriteIDs,
 		RewriteTimestamps: loadgencfg.Config.RewriteTimestamps,
 		Headers:           loadgencfg.Config.Headers,
+		Protocol:          loadgencfg.Config.Protocol,
 	})
 	if err != nil {
 		// panicing ensures that the error is reported

--- a/internal/loadgen/config/config.go
+++ b/internal/loadgen/config/config.go
@@ -31,6 +31,7 @@ var Config struct {
 	RewriteTransactionNames   bool
 	RewriteTransactionTypes   bool
 	Headers                   map[string]string
+	Protocol                  string
 }
 
 type RateFlag struct {
@@ -112,6 +113,7 @@ func init() {
 	)
 	flag.Var(&Config.EventRate, "event-rate", "Event rate in format of {burst}/{interval}. For example, 200/5s, <= 0 values evaluate to Inf (default 0/s)")
 	flag.BoolVar(&Config.IgnoreErrors, "ignore-errors", false, "Ignore HTTP errors while sending events")
+	flag.StringVar(&Config.Protocol, "protocol", "apm/http", "One of: apm/http, otlp/http")
 
 	rewriteNames := map[string]*bool{
 		"service.name":        &Config.RewriteServiceNames,


### PR DESCRIPTION
## Context

The MIS benchmarks are failing with:

```
apmbench-648… │ panic: invalid or unsupported protocol ()
apmbench-648… │ 
apmbench-648… │ goroutine 5 [running]:
apmbench-648… │ main.newEventHandler({0x0?, 0x0?}, {0xbec9d5, 0x8}, 0xc00050c050)
apmbench-648… │ 	/opt/apm-perf/cmd/apmbench/bench.go:215 +0x2c6
apmbench-648… │ main.benchmarkAgent(0x0?, 0x0?, {0xbec9d5?, 0x0?})
apmbench-648… │ 	/opt/apm-perf/cmd/apmbench/bench.go:221 +0x34
apmbench-648… │ main.BenchmarkAgentAll(0x0?, 0x0?)
apmbench-648… │ 	/opt/apm-perf/cmd/apmbench/bench.go:74 +0x25
apmbench-648… │ main.runOne.func1.1()
apmbench-648… │ 	/opt/apm-perf/cmd/apmbench/run.go:123 +0x67
apmbench-648… │ created by main.runOne.func1
apmbench-648… │ 	/opt/apm-perf/cmd/apmbench/run.go:121 +0xdb
apmbench-648… │      ┊ Scheduled       - <1s
apmbench-648… │      ┊ Initialized     - <1s
apmbench-648… │      ┊ Ready           - (…) Pending
```

in https://github.com/elastic/apm-managed-service/actions/runs/7858017783/job/21442506285

## Details

This change sets `apm/http` as the default in the loadgen config.

## Workflow run

Verified to work in https://github.com/elastic/apm-managed-service/actions/runs/7862337046/job/21451692616
