### PR TITLE
apmsoak: do not stop on errors, continue until SIGINT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ build:
 
 .PHONY: test
 test: go.mod
-	go test -v ./...
+	go test -race -v ./...
 
 .PHONY: package
 package: BASE_IMAGE_VERSION=$$(cat .go-version)

--- a/cmd/apmsoak/run.go
+++ b/cmd/apmsoak/run.go
@@ -26,7 +26,7 @@ type RunOptions struct {
 	BypassProxy   bool
 	Loglevel      string
 	IgnoreErrors  bool
-	ForceShutdown bool
+	RunForever    bool
 }
 
 func (opts *RunOptions) toRunnerConfig() (*soaktest.RunnerConfig, error) {
@@ -49,7 +49,7 @@ func (opts *RunOptions) toRunnerConfig() (*soaktest.RunnerConfig, error) {
 		APIKeys:       apiKeys,
 		BypassProxy:   opts.BypassProxy,
 		IgnoreErrors:  opts.IgnoreErrors,
-		ForceShutdown: opts.ForceShutdown,
+		RunForever:    opts.RunForever,
 	}, nil
 }
 
@@ -88,7 +88,7 @@ func NewCmdRun() *cobra.Command {
 	cmd.Flags().BoolVar(&options.BypassProxy, "bypass-proxy", false, "Detach from proxy dependency and provide projectID via header. Useful when testing locally")
 	cmd.Flags().StringVar(&options.Loglevel, "log-level", "info", "Specify the log level to use when running this command. Supported values: debug, info, warn, error")
 	cmd.Flags().BoolVar(&options.IgnoreErrors, "ignore-errors", false, "Ignore HTTP errors while sending events")
-	cmd.Flags().BoolVar(&options.ForceShutdown, "force-shutdown", false, "Continue running the soak test until a signal is received to stop it")
+	cmd.Flags().BoolVar(&options.RunForever, "run-forever", false, "Continue running the soak test until a signal is received to stop it")
 	return cmd
 }
 

--- a/cmd/apmsoak/run.go
+++ b/cmd/apmsoak/run.go
@@ -27,6 +27,7 @@ type RunOptions struct {
 	APIKeys       string
 	BypassProxy   bool
 	Loglevel      string
+	IgnoreErrors  bool
 }
 
 func (opts *RunOptions) toRunnerConfig() (*soaktest.RunnerConfig, error) {
@@ -48,6 +49,7 @@ func (opts *RunOptions) toRunnerConfig() (*soaktest.RunnerConfig, error) {
 		SecretToken:   opts.SecretToken,
 		APIKeys:       apiKeys,
 		BypassProxy:   opts.BypassProxy,
+		IgnoreErrors:  opts.IgnoreErrors,
 	}, nil
 }
 
@@ -89,6 +91,7 @@ func NewCmdRun() *cobra.Command {
 	cmd.Flags().StringVar(&options.APIKeys, "api-keys", "", "API keys for managed service. Specify key value pairs as `project_id_1:my_api_key,project_id_2:my_key`")
 	cmd.Flags().BoolVar(&options.BypassProxy, "bypass-proxy", false, "Detach from proxy dependency and provide projectID via header. Useful when testing locally")
 	cmd.Flags().StringVar(&options.Loglevel, "log-level", "info", "Specify the log level to use when running this command. Supported values: debug, info, warn, error")
+	cmd.Flags().BoolVar(&options.IgnoreErrors, "ignore-errors", false, "Do not report as a failure HTTP responses with status code different than 200")
 	return cmd
 }
 

--- a/cmd/apmsoak/run.go
+++ b/cmd/apmsoak/run.go
@@ -87,7 +87,7 @@ func NewCmdRun() *cobra.Command {
 	cmd.Flags().StringVar(&options.APIKeys, "api-keys", "", "API keys for managed service. Specify key value pairs as `project_id_1:my_api_key,project_id_2:my_key`")
 	cmd.Flags().BoolVar(&options.BypassProxy, "bypass-proxy", false, "Detach from proxy dependency and provide projectID via header. Useful when testing locally")
 	cmd.Flags().StringVar(&options.Loglevel, "log-level", "info", "Specify the log level to use when running this command. Supported values: debug, info, warn, error")
-	cmd.Flags().BoolVar(&options.IgnoreErrors, "ignore-errors", false, "Do not report as a failure HTTP responses with status code different than 200")
+	cmd.Flags().BoolVar(&options.IgnoreErrors, "ignore-errors", false, "Ignore HTTP errors while sending events")
 	cmd.Flags().BoolVar(&options.ForceShutdown, "force-shutdown", false, "Continue running the soak test until a signal is received to stop it")
 	return cmd
 }

--- a/cmd/apmsoak/run.go
+++ b/cmd/apmsoak/run.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/spf13/cobra"
 	"go.elastic.co/ecszap"
@@ -68,9 +69,9 @@ func NewCmdRun() *cobra.Command {
 				logger.Fatal("Fail to initialize runner", zap.Error(err))
 			}
 
-			// Graceful shutdown driven by SIGINT.
+			// Graceful shutdown driven by SIGINT or SIGTERM.
 			// Nothing else is expected to stop the runner.
-			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt)
+			ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 			defer cancel()
 
 			if err := runner.Run(ctx); err != nil {

--- a/internal/loadgen/eventhandler.go
+++ b/internal/loadgen/eventhandler.go
@@ -35,7 +35,7 @@ type EventHandlerParams struct {
 	Limiter                   *rate.Limiter
 	Rand                      *rand.Rand
 	IgnoreErrors              bool
-	ForceShutdown             bool
+	RunForever                bool
 	RewriteIDs                bool
 	RewriteServiceNames       bool
 	RewriteServiceNodeNames   bool
@@ -121,7 +121,7 @@ func newAPMEventHandler(p EventHandlerParams) (*eventhandler.Handler, error) {
 		Limiter:                   p.Limiter,
 		Rand:                      p.Rand,
 		IgnoreErrors:              p.IgnoreErrors,
-		ForceShutdown:             p.ForceShutdown,
+		RunForever:                p.RunForever,
 		RewriteIDs:                p.RewriteIDs,
 		RewriteServiceNames:       p.RewriteServiceNames,
 		RewriteServiceNodeNames:   p.RewriteServiceNodeNames,

--- a/internal/loadgen/eventhandler.go
+++ b/internal/loadgen/eventhandler.go
@@ -35,6 +35,7 @@ type EventHandlerParams struct {
 	Limiter                   *rate.Limiter
 	Rand                      *rand.Rand
 	IgnoreErrors              bool
+	ForceShutdown             bool
 	RewriteIDs                bool
 	RewriteServiceNames       bool
 	RewriteServiceNodeNames   bool
@@ -120,6 +121,7 @@ func newAPMEventHandler(p EventHandlerParams) (*eventhandler.Handler, error) {
 		Limiter:                   p.Limiter,
 		Rand:                      p.Rand,
 		IgnoreErrors:              p.IgnoreErrors,
+		ForceShutdown:             p.ForceShutdown,
 		RewriteIDs:                p.RewriteIDs,
 		RewriteServiceNames:       p.RewriteServiceNames,
 		RewriteServiceNodeNames:   p.RewriteServiceNodeNames,

--- a/internal/loadgen/eventhandler/handler.go
+++ b/internal/loadgen/eventhandler/handler.go
@@ -100,9 +100,9 @@ type Config struct {
 	// events using the event handler.
 	IgnoreErrors bool
 
-	// ForceShutdown when set to true, will keep the handler running
+	// RunForever when set to true, will keep the handler running
 	// until a signal is received to stop it.
-	ForceShutdown bool
+	RunForever bool
 
 	// Writer writes replayable events to buffer.
 	Writer EventWriter
@@ -267,7 +267,7 @@ func (h *Handler) SendBatchesInLoop(ctx context.Context) error {
 			return ctx.Err()
 		default:
 			if _, err := h.sendBatches(ctx, &s); err != nil {
-				if h.config.ForceShutdown {
+				if h.config.RunForever {
 					h.logger.Error("failed to send batch of events", zap.Error(err))
 					continue
 				}

--- a/internal/loadgen/eventhandler/handler.go
+++ b/internal/loadgen/eventhandler/handler.go
@@ -269,7 +269,9 @@ func (h *Handler) SendBatchesInLoop(ctx context.Context) error {
 				return
 			default:
 				if _, err := h.sendBatches(ctx, &s); err != nil {
-					sendErrs <- err
+					if !h.config.IgnoreErrors {
+						sendErrs <- err
+					}
 					continue
 				}
 				// safeguard `s.sent` so that it doesn't exceed math.MaxInt

--- a/internal/soaktest/runner.go
+++ b/internal/soaktest/runner.go
@@ -36,9 +36,9 @@ type RunnerConfig struct {
 	APIKeys       map[string]string
 	BypassProxy   bool
 	IgnoreErrors  bool
-	// ForceShutdown when set to true, will keep the handler running
+	// RunForever when set to true, will keep the handler running
 	// until a signal is received to stop it.
-	ForceShutdown bool
+	RunForever bool
 }
 
 type Runner struct {
@@ -75,7 +75,7 @@ func NewRunner(config *RunnerConfig, logger *zap.Logger) (*Runner, error) {
 func (runner *Runner) Run(ctx context.Context) error {
 	// Apply graceful shutdown driven by SIGINT or SIGTERM
 	// in case the config is set.
-	if runner.config.ForceShutdown {
+	if runner.config.RunForever {
 		var cancel context.CancelFunc
 		ctx, cancel = signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 		defer cancel()
@@ -179,7 +179,7 @@ func getHandlerParams(runnerConfig *RunnerConfig, config ScenarioConfig) (loadge
 		APIKey:                    config.APIKey,
 		Token:                     runnerConfig.SecretToken,
 		IgnoreErrors:              runnerConfig.IgnoreErrors,
-		ForceShutdown:             runnerConfig.ForceShutdown,
+		RunForever:                runnerConfig.RunForever,
 		Limiter:                   loadgen.GetNewLimiter(burst, interval),
 		RewriteIDs:                true,
 		RewriteServiceNames:       config.RewriteServiceNames,

--- a/internal/soaktest/runner.go
+++ b/internal/soaktest/runner.go
@@ -33,6 +33,7 @@ type RunnerConfig struct {
 	SecretToken   string
 	APIKeys       map[string]string
 	BypassProxy   bool
+	IgnoreErrors  bool
 }
 
 type Runner struct {
@@ -164,6 +165,7 @@ func getHandlerParams(runnerConfig *RunnerConfig, config ScenarioConfig) (loadge
 		URL:                       serverURL.String(),
 		APIKey:                    config.APIKey,
 		Token:                     runnerConfig.SecretToken,
+		IgnoreErrors:              runnerConfig.IgnoreErrors,
 		Limiter:                   loadgen.GetNewLimiter(burst, interval),
 		RewriteIDs:                true,
 		RewriteServiceNames:       config.RewriteServiceNames,

--- a/internal/soaktest/runner_test.go
+++ b/internal/soaktest/runner_test.go
@@ -1,0 +1,79 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package soaktest
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_getEventRate(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventRate string
+		burst     int
+		rate      time.Duration
+		wantErr   bool
+	}{
+		{
+			name:      "valid event rate",
+			eventRate: "10/1s",
+			burst:     10,
+			rate:      time.Second,
+			wantErr:   false,
+		},
+		{
+			name:      "valid event rate with milliseconds",
+			eventRate: "100/1ms",
+			burst:     100,
+			rate:      time.Millisecond,
+			wantErr:   false,
+		},
+		{
+			name:      "infinite event rate removes limiter",
+			eventRate: "-1/s",
+			burst:     -1,
+			rate:      time.Second,
+			wantErr:   false,
+		},
+		{
+
+			name:      "invalid event rate format",
+			eventRate: "0/abc",
+			burst:     0,
+			rate:      0,
+			wantErr:   true,
+		},
+		{
+			name:      "invalid burst format",
+			eventRate: "abc/1s",
+			burst:     0,
+			rate:      0,
+			wantErr:   true,
+		},
+		{
+			name:      "invalid format missing slash",
+			eventRate: "100000",
+			burst:     0,
+			rate:      0,
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := getEventRate(tt.eventRate)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getEventRate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.burst {
+				t.Errorf("getEventRate() got = %v, want %v", got, tt.burst)
+			}
+			if got1 != tt.rate {
+				t.Errorf("getEventRate() got1 = %v, want %v", got1, tt.rate)
+			}
+		})
+	}
+}

--- a/internal/soaktest/scenario.go
+++ b/internal/soaktest/scenario.go
@@ -33,7 +33,7 @@ type ScenarioConfig struct {
 	AgentsReplicas int `yaml:"agent_replicas"`
 	// EventRate represent the rate of events generated.
 	// Must be in the format <number of events>/<time>. <time> is parsed
-	// as a Go time value.
+	// as a Go time.Duration value.
 	// FIXME: improve comment
 	EventRate string `yaml:"event_rate"`
 	// Headers contains additional HTTP headers to attach to every data


### PR DESCRIPTION
### Reason for this PR

When ingesting traffic `apmsoak` will stop running on the first error returned by the server.

### Details

* add testing to parsing the event rate
* include a signal trap for SIGINT to shutdown all workers

### Further work

We should understand with @elastic/observablt-robots if there's an impact to quality gates with this change.