### PR TITLE
fix: use correct config field for agent_replicas

### DIFF
--- a/cmd/apmsoak/scenarios.yml
+++ b/cmd/apmsoak/scenarios.yml
@@ -18,13 +18,13 @@ scenarios:
   apm-server:
     - event_rate: 10000/1s
       agent_name: apm-go
-      agents_replicas: 3
+      agent_replicas: 3
     - event_rate: 10000/1s
       agent_name: apm-nodejs
-      agents_replicas: 3
+      agent_replicas: 3
     - event_rate: 10000/1s
       agent_name: apm-python
-      agents_replicas: 3
+      agent_replicas: 3
     - event_rate: 10000/1s
       agent_name: apm-ruby
-      agents_replicas: 3
+      agent_replicas: 3

--- a/internal/soaktest/runner.go
+++ b/internal/soaktest/runner.go
@@ -93,10 +93,10 @@ func (runner *Runner) Run(ctx context.Context) error {
 	for _, config := range runner.scenarioConfigs {
 		config := config
 		// when not specified, default to 1
-		if config.AgentsReplicas <= 0 {
-			config.AgentsReplicas = 1
+		if config.AgentReplicas <= 0 {
+			config.AgentReplicas = 1
 		}
-		for i := 0; i < config.AgentsReplicas; i++ {
+		for i := 0; i < config.AgentReplicas; i++ {
 			runner.logger.Debug(fmt.Sprintf("agent: %s, replica %d, event-rate: %s", config.AgentName, i, config.EventRate))
 			g.Go(func() error {
 				rng := rand.New(rand.NewSource(rngseed))

--- a/internal/soaktest/runner.go
+++ b/internal/soaktest/runner.go
@@ -97,7 +97,7 @@ func (runner *Runner) Run(ctx context.Context) error {
 			config.AgentsReplicas = 1
 		}
 		for i := 0; i < config.AgentsReplicas; i++ {
-			runner.logger.Debug(fmt.Sprintf("agent: %s, replica %d", config.AgentName, i))
+			runner.logger.Debug(fmt.Sprintf("agent: %s, replica %d, event-rate: %s", config.AgentName, i, config.EventRate))
 			g.Go(func() error {
 				rng := rand.New(rand.NewSource(rngseed))
 				return runAgent(gCtx, runner, config, rng)

--- a/internal/soaktest/scenario.go
+++ b/internal/soaktest/scenario.go
@@ -28,9 +28,9 @@ type ScenarioConfig struct {
 	// For OTLP agents this value bust be <otlp-traces|metrics|logs>, as
 	// the OTLP protocol uses different endpoints for different data types.
 	AgentName string `yaml:"agent_name"`
-	// AgentsReplicas is the number of different agents that this scenario
+	// AgentReplicas is the number of different agents that this scenario
 	// will emulate when generating data points.
-	AgentsReplicas int `yaml:"agent_replicas"`
+	AgentReplicas int `yaml:"agent_replicas"`
 	// EventRate represent the rate of events generated.
 	// Must be in the format <number of events>/<time>. <time> is parsed
 	// as a Go time.Duration value.


### PR DESCRIPTION
fix typo in cmd/apmsoak/scenarios.yml for `agent_replicas` as per https://github.com/elastic/apm-perf/blob/main/internal/soaktest/scenario.go#L33 and print event rate.