### PR TITLE
Sleep before collecting metrics

### DIFF
--- a/cmd/apmbench/run.go
+++ b/cmd/apmbench/run.go
@@ -91,13 +91,6 @@ func Run(
 					return fmt.Errorf("benchmark %q failed", name)
 				}
 				fmt.Printf("%-*s\t%s\n", maxLen, name, result.benchResult)
-				// Sleep to allow any remaining data to be consumed by the pipelines
-				// so that they don't pollute the result of the next benchmark run.
-				//
-				// TODO (lahsivjar): Make this deterministic by introducing cleanup
-				// metrics. We can watch the cleanup metrics to reach to a specified
-				// threshold and then run the next benchmark.
-				time.Sleep(time.Minute)
 			}
 		}
 	}
@@ -126,6 +119,15 @@ func runOne(
 
 		result.skipped = b.Skipped()
 		result.failed = b.Failed()
+
+		// Sleep to allow any remaining data to be consumed by the pipelines
+		// so that they don't pollute the result of the next benchmark run.
+		//
+		// TODO (lahsivjar): Make this deterministic by introducing cleanup
+		// metrics. We can watch the cleanup metrics to reach to a specified
+		// threshold and then run the next benchmark.
+		time.Sleep(time.Minute)
+
 		extraMetrics(b)
 	})
 	return result


### PR DESCRIPTION
Sleep before collecting metrics so that we collect the metrics for events consumed by the data pipeline during the sleep.