### PR TITLE
[apmbench] utilize cleanup keys for deterministic post benchmark metrics

### DIFF
--- a/cmd/apmbench/config.go
+++ b/cmd/apmbench/config.go
@@ -22,6 +22,14 @@ var cfg struct {
 	// Sorted list of agents count to be used for benchmarking
 	AgentsList                 []int
 	BenchmarkTelemetryEndpoint string
+	// CleanupKeys defines a list of telemetry keys that will be
+	// used to determine if a specific benchmark funciton has run
+	// to completion including draining of all associated data. The
+	// cleanup keys, if specified, must be returned by the benchmark
+	// telemetry endpoint. The metric associated with each key must
+	// go to zero on completion of a benchmark.
+	CleanupKeys []string
+	Debug       bool
 }
 
 func init() {
@@ -69,4 +77,19 @@ func init() {
 		},
 	)
 	flag.StringVar(&cfg.BenchmarkTelemetryEndpoint, "benchmark-telemetry-endpoint", "", "Telemetry endpoint that exposed benchmark telemetry data with reset capabilities")
+	flag.Func("cleanup-keys", "comma-separated `list` of metric keys returned by the telemetry endpoint to monitor cleanup status after a benchmark run",
+		func(raw string) error {
+			var keys []string
+			for _, val := range strings.Split(raw, ",") {
+				val = strings.TrimSpace(val)
+				if val == "" {
+					continue
+				}
+				keys = append(keys, val)
+			}
+			cfg.CleanupKeys = keys
+			return nil
+		},
+	)
+	flag.BoolVar(&cfg.Debug, "debug", false, "setup debug logging level")
 }

--- a/cmd/apmbench/main.go
+++ b/cmd/apmbench/main.go
@@ -95,8 +95,7 @@ func assertCleanupState(ctx context.Context, telemetry telemetry, logger *zap.Lo
 		// If no cleanup keys are specified then, as a best effort, sleep
 		// for a specific duration to ensure the pipelines have a chance to
 		// be fully consumed and metrics to be reported.
-		logger.Info("no cleanup keys specified, sleep for 1 minute before proceeding")
-		time.Sleep(time.Minute)
+		logger.Warn("no cleanup keys specified, benchmark results may get corrupted")
 		return nil
 	}
 

--- a/cmd/apmbench/main.go
+++ b/cmd/apmbench/main.go
@@ -5,9 +5,12 @@
 package main
 
 import (
+	"context"
 	"flag"
+	"fmt"
 	"log"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 )
@@ -15,7 +18,7 @@ import (
 func main() {
 	flag.Parse()
 
-	logger, err := zap.NewProduction()
+	logger, err := setupLogger()
 	if err != nil {
 		log.Fatalf("failed to setup logger: %v", err)
 	}
@@ -25,18 +28,37 @@ func main() {
 	if cfg.BenchmarkTelemetryEndpoint != "" {
 		telemetry := telemetry{endpoint: cfg.BenchmarkTelemetryEndpoint}
 		extraMetrics = func(b *testing.B) {
+			// TODO (lahsivjar): get a context with timeout based on test timeout
+			if err := assertCleanupState(context.Background(), telemetry, logger); err != nil {
+				logger.Warn(
+					"failed to get cleanup metric, continuing without cleanup",
+					zap.Error(err),
+				)
+			}
 			m, err := telemetry.GetAll()
 			if err != nil {
-				logger.Warn("failed to retrive benchmark metrics", zap.Error(err))
+				logger.Warn(
+					"failed to retrive benchmark metrics, extra metrics will not be reported",
+					zap.Error(err),
+				)
 				return
 			}
-			for unit, val := range m {
-				b.ReportMetric(val, unit)
+			// extra metrics may be aggregated by a grouping key. We can sum all the
+			// values for the grouping key to get the final benchmark results.
+			for unit, grp := range m {
+				var total float64
+				for _, val := range grp {
+					total += val
+				}
+				b.ReportMetric(total, unit)
 			}
 		}
 		resetStoreFunc = func() {
 			if err := telemetry.Reset(); err != nil {
-				logger.Warn("failed to reset store, benchmark report may be corrupted", zap.Error(err))
+				logger.Warn(
+					"failed to reset store, benchmark report may be corrupted",
+					zap.Error(err),
+				)
 			}
 		}
 	}
@@ -58,6 +80,75 @@ func main() {
 		logger.Fatal("failed to run benchmarks", zap.Error(err))
 	}
 	logger.Info("finished running benchmarks")
+}
+
+func setupLogger() (*zap.Logger, error) {
+	loggerCfg := zap.NewProductionConfig()
+	if cfg.Debug {
+		loggerCfg.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
+	}
+	return loggerCfg.Build()
+}
+
+func assertCleanupState(ctx context.Context, telemetry telemetry, logger *zap.Logger) error {
+	if len(cfg.CleanupKeys) == 0 {
+		// If no cleanup keys are specified then, as a best effort, sleep
+		// for a specific duration to ensure the pipelines have a chance to
+		// be fully consumed and metrics to be reported.
+		logger.Info("no cleanup keys specified, sleep for 1 minute before proceeding")
+		time.Sleep(time.Minute)
+		return nil
+	}
+
+	t := time.NewTicker(5 * time.Second)
+	defer t.Stop()
+
+	var idx int
+	for {
+		// cleanup is successful if we have asserted all the cleanup keys.
+		if idx == len(cfg.CleanupKeys) {
+			logger.Debug("cleanup condition satisfied")
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("cleanup condition not satisfied: %w", ctx.Err())
+		case <-t.C:
+			for idx < len(cfg.CleanupKeys) {
+				key := cfg.CleanupKeys[idx]
+				m, err := telemetry.Get(key)
+				if err != nil {
+					logger.Warn(
+						"failed to get cleanup metric, will be retried",
+						zap.Error(err),
+						zap.String("key", key),
+					)
+					break
+				}
+				ok := true
+				for gid, v := range m {
+					if v != 0 {
+						logger.Debug(
+							"cleanup condition not satisfied, will be retried",
+							zap.String("key", key),
+							zap.String("group", gid),
+							zap.Float64("val", v),
+						)
+						ok = false
+						break
+					}
+				}
+				// If a cleanup key fails then there is no need to try anything else.
+				if !ok {
+					break
+				}
+				// If the cleanup metric is successful for the current key then
+				// move onto the next key.
+				idx++
+			}
+		}
+	}
 }
 
 func init() {

--- a/cmd/apmbench/run.go
+++ b/cmd/apmbench/run.go
@@ -13,7 +13,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"go.elastic.co/apm/v2/stacktrace"
 	"golang.org/x/time/rate"
@@ -91,13 +90,6 @@ func Run(
 					return fmt.Errorf("benchmark %q failed", name)
 				}
 				fmt.Printf("%-*s\t%s\n", maxLen, name, result.benchResult)
-				// Sleep to allow any remaining data to be consumed by the pipelines
-				// so that they don't pollute the result of the next benchmark run.
-				//
-				// TODO (lahsivjar): Make this deterministic by introducing cleanup
-				// metrics. We can watch the cleanup metrics to reach to a specified
-				// threshold and then run the next benchmark.
-				time.Sleep(time.Minute)
 			}
 		}
 	}
@@ -113,7 +105,6 @@ func runOne(
 		loadgencfg.Config.EventRate.Interval,
 	)
 	result.benchResult = testing.Benchmark(func(b *testing.B) {
-		b.ResetTimer()
 		signal := make(chan struct{})
 		// fn can panic or call runtime.Goexit, stopping the goroutine.
 		// When that happens the function won't return and ok=false will


### PR DESCRIPTION
Closes https://github.com/elastic/apm-perf/issues/37