### PR TITLE
Fix out-of-bounds slice read panic

### DIFF
--- a/internal/loadgen/eventhandler/apm-writer.go
+++ b/internal/loadgen/eventhandler/apm-writer.go
@@ -11,9 +11,9 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-// writeAPMEvents writes to buffers in pooledWriter JSON formatted events that can be replayed.
+// writeAPMEvents writes to buffers in eventWriter JSON formatted events that can be replayed.
 // Implements EventWriter interface.
-func writeAPMEvents(config Config, minTimestamp time.Time, w *pooledWriter, b batch, baseTimestamp time.Time, randomBits uint64) error {
+func writeAPMEvents(config Config, minTimestamp time.Time, w *eventWriter, b batch, baseTimestamp time.Time, randomBits uint64) error {
 	rewriteAny := config.RewriteTimestamps ||
 		config.RewriteIDs ||
 		config.RewriteServiceNames ||

--- a/internal/loadgen/eventhandler/event.go
+++ b/internal/loadgen/eventhandler/event.go
@@ -12,4 +12,4 @@ type EventCollector interface {
 	Process([]byte) event
 }
 
-type EventWriter func(config Config, minTimestamp time.Time, w *pooledWriter, b batch, baseTimestamp time.Time, randomBits uint64) error
+type EventWriter func(config Config, minTimestamp time.Time, w *eventWriter, b batch, baseTimestamp time.Time, randomBits uint64) error


### PR DESCRIPTION
Fixes #75 

See comments on issue. In error cases, calls to `http.Client.Do()` may return while the request body is still being processed and transmitted. For example, the server may drop the connection which would cause `client.Do` to return early, but the http library may still be processing the request internally in a separate roundtripper goroutine that is still reading from the request body.

Concurrent reads and writes from/to the request body can cause panics (especially if it's a `bytes.Buffer`). This means we have no choice but to consider the request body immutable after it is handed over to the HTTP library, and thus we cannot reuse the `pooledWriter`.

We could most likely optimize things and reuse the writer in success cases - but unless people have concerns, I thought I'd opt for simplicity (but with an ugly preallocate call) - apmbench doesn't seem to go over 300MB resident size with this. Happy to revisit if people feel this needs a little more love.