### PR TITLE
feat: bump base image version to go 1.22

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Base image for build
-ARG base_image_version=1.20.7
+ARG base_image_version=1.22
 FROM golang:${base_image_version} as builder
 
 # Switch workdir


### PR DESCRIPTION
The go.mod version was bumped to go 1.21 but the containerfile is still using go 1.20 causing a build failure when building the image