### PR TITLE
container: speed up build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,8 @@
 # Base image for build
 ARG base_image_version=1.22
-FROM golang:${base_image_version} as builder
+# We are doing cross compilation, this speeds things up
+# https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/
+FROM --platform=$BUILDPLATFORM golang:${base_image_version} as builder
 
 # Switch workdir
 WORKDIR /opt/apm-perf

--- a/Containerfile
+++ b/Containerfile
@@ -7,6 +7,10 @@ FROM --platform=$BUILDPLATFORM golang:${base_image_version} as builder
 # Switch workdir
 WORKDIR /opt/apm-perf
 
+# Use dedicated layer for Go dependency, cached until they changes
+COPY go.mod go.sum ./
+RUN go mod download
+
 # Copy files
 COPY . .
 

--- a/Containerfile
+++ b/Containerfile
@@ -15,9 +15,11 @@ RUN go mod download
 COPY . .
 
 # Build 
-RUN \
-  go mod download \
-  && make build
+ARG TARGETOS TARGETARCH
+# Leverage mounts to cache relevant Go paths
+RUN --mount=type=cache,target=/root/.cache/go-build \
+  --mount=type=cache,target=/go/pkg \
+  GOOS=$TARGETOS GOARCH=$TARGETARCH make build
 
 # Base image for build
 FROM debian:bookworm


### PR DESCRIPTION
This PR speeds up container build by applying some cross-compilation optimization in the `Containerfile`.

I was able to jump from minutes to seconds in building the `apm-perf` image. These changes do not impact the current builds (if not enhancing the speed in cross-compilation scenarios).

One noteworthy change is the addition of a dedicated layer for Go module dependencies, which helps reusing the same layer unless there has been a change in dependencies.

