### PR TITLE
fix: update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @elastic/apm-server
+* @elastic/obs-ds-intake-services


### PR DESCRIPTION
repo permission was updated to use the obs-ds-intake-services group, breaking the codeowner file using the old/deprecated apm-server
