### PR TITLE
refactor: remove duplicate signal handling

### DIFF
--- a/internal/soaktest/runner.go
+++ b/internal/soaktest/runner.go
@@ -84,7 +84,7 @@ func (runner *Runner) Run(ctx context.Context) error {
 		}()
 	}
 
-  g, gCtx := errgroup.WithContext(ctx)
+	g, gCtx := errgroup.WithContext(ctx)
 	// Create a Rand with the same seed for each agent, so we randomise their IDs consistently.
 	var rngseed int64
 	err := binary.Read(cryptorand.Reader, binary.LittleEndian, &rngseed)


### PR DESCRIPTION
signal is handled in the main function and the context is propagated already