### PR TITLE
feat: default rewrite-ids and rewrite-timestamp to true

### DIFF
--- a/internal/loadgen/config/config.go
+++ b/internal/loadgen/config/config.go
@@ -86,14 +86,14 @@ func init() {
 	flag.BoolVar(
 		&Config.RewriteTimestamps,
 		"rewrite-timestamps",
-		false,
+		true,
 		"rewrite event timestamps every iteration, maintaining relative offsets",
 	)
 
 	flag.BoolVar(
 		&Config.RewriteIDs,
 		"rewrite-ids",
-		false,
+		true,
 		"rewrite event IDs every iteration, maintaining event relationships",
 	)
 	flag.Func("header",


### PR DESCRIPTION
to avoid breaking changes default to rewriting ids and timestamps

the flag were being ignored and always true before a recent fix so this PR keep the behaviour for when no flag is set.

Closes https://github.com/elastic/apm-perf/issues/150