### PR TITLE
apmsoak: log parsed config

### DIFF
--- a/cmd/apmsoak/run.go
+++ b/cmd/apmsoak/run.go
@@ -99,6 +99,8 @@ func NewCmdRun() *cobra.Command {
 				logger.Fatal("Fail to parse flags", zap.Error(err))
 			}
 
+			logger.Debug("parsed configs", zap.Object("config", config))
+
 			runner, err := soaktest.NewRunner(config, logger)
 			if err != nil {
 				logger.Fatal("Fail to initialize runner", zap.Error(err))


### PR DESCRIPTION
Print parsed configs in debug logs to help with debugging misbehaviours.

Sensitive values are partially redacted to help with debugging without
disclosing full information.
