### PR TITLE
apmbench: fix benchtime flag

### DIFF
--- a/cmd/apmbench/config.go
+++ b/cmd/apmbench/config.go
@@ -11,12 +11,11 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 )
 
 var cfg struct {
 	Count     uint
-	Benchtime time.Duration
+	Benchtime string
 	RunRE     *regexp.Regexp
 	SkipRE    *regexp.Regexp
 	// Sorted list of agents count to be used for benchmarking
@@ -36,7 +35,7 @@ func init() {
 	cfg.AgentsList = []int{1}
 
 	flag.UintVar(&cfg.Count, "count", 1, "run benchmarks `n` times")
-	flag.DurationVar(&cfg.Benchtime, "benchtime", time.Second, "run each benchmark for duration `d`")
+	flag.StringVar(&cfg.Benchtime, "benchtime", "1s", "run each benchmark for duration `d` or N times if `d` is of the form Nx")
 	flag.Func("run", "run only benchmarks matching `regexp`", func(restr string) error {
 		if restr != "" {
 			re, err := regexp.Compile(restr)

--- a/cmd/apmbench/run.go
+++ b/cmd/apmbench/run.go
@@ -44,7 +44,7 @@ func Run(
 	}
 
 	// Set `test.benchtime` flag based on the custom `benchtime` flag.
-	if err := flag.Set("test.benchtime", cfg.Benchtime.String()); err != nil {
+	if err := flag.Set("test.benchtime", cfg.Benchtime); err != nil {
 		return fmt.Errorf("failed to set test.benchtime flag: %w", err)
 	}
 


### PR DESCRIPTION
This PR fixes benchtime flag to be compliant with https://golang.google.cn/src/testing/benchmark.go "run each benchmark for duration `d` or N times if `d` is of the form Nx". This will allow us to use both "-benchtime=10s" and "-benchtime=10x" in apmbench properly.