### PR TITLE
feat(moxy): return empty agentcfg instead of logging an error

### DIFF
--- a/internal/proxy/stub_es.go
+++ b/internal/proxy/stub_es.go
@@ -86,6 +86,10 @@ func (h stubES) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	case "/":
 		_, _ = w.Write(h.info)
 		return
+	case "/.apm-agent-configuration/_search":
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+		w.WriteHeader(http.StatusOK)
 	case "/_license":
 		_, _ = w.Write(h.license)
 		return


### PR DESCRIPTION
## 🧑‍💻 What

return an empty response to avoid logging errors when apm-server uses the es fetcher to search for agentcfg

## ❓ Why

Discovered while benchmarking badger v4 and spotting errors in the logs

## ✅ How

run apm-server+moxy

observe errors in apm-server logs and moxy erroring because of an unknown path