### PR TITLE
deps: Fix inmemexporter after dependency updates

### DIFF
--- a/cmd/otelinmemexporter/factory.go
+++ b/cmd/otelinmemexporter/factory.go
@@ -17,7 +17,7 @@ import (
 
 func NewFactory() exporter.Factory {
 	return exporter.NewFactory(
-		componentID,
+		component.MustNewType(componentID),
 		createDefaultConfig,
 		exporter.WithMetrics(
 			createMetricsExporter,
@@ -34,7 +34,7 @@ func createDefaultConfig() component.Config {
 
 func createMetricsExporter(
 	ctx context.Context,
-	settings exporter.CreateSettings,
+	settings exporter.Settings,
 	rawCfg component.Config,
 ) (exporter.Metrics, error) {
 	cfg := rawCfg.(*Config)
@@ -49,13 +49,13 @@ func createMetricsExporter(
 	newServer(store, cfg.Server.Endpoint, logger).Start()
 
 	exp := new(*cfg, store, logger)
-	return exporterhelper.NewMetricsExporter(
+	return exporterhelper.NewMetrics(
 		ctx, settings, cfg,
 		exp.consumeMetrics,
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		// Disable Timeout/RetryOnFailure and SendingQueue
-		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
+		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0}),
 		exporterhelper.WithRetry(configretry.BackOffConfig{Enabled: false}),
-		exporterhelper.WithQueue(exporterhelper.QueueSettings{Enabled: false}),
+		exporterhelper.WithQueue(exporterhelper.QueueConfig{Enabled: false}),
 	)
 }

--- a/cmd/otelinmemexporter/go.mod
+++ b/cmd/otelinmemexporter/go.mod
@@ -1,7 +1,8 @@
 module github.com/elastic/apm-perf/cmd/otelinmemexporter
 
-go 1.22
-toolchain go1.22.5
+go 1.22.0
+
+toolchain go1.23.2
 
 require (
 	github.com/gorilla/mux v1.8.1


### PR DESCRIPTION
The inmemexporter was broken after the upstream otel dependencies were updated