### PR TITLE
apmtelemetrygen: Add bytes written to logs

### DIFF
--- a/cmd/apmtelemetrygen/main.go
+++ b/cmd/apmtelemetrygen/main.go
@@ -132,7 +132,7 @@ func newRunCmd() *cobra.Command {
 	cmd.Flags().StringVar(&options.ServerURL, "server-url", "", "Server URL (default http://127.0.0.1:8200)")
 	cmd.Flags().StringVar(&options.SecretToken, "secret-token", "", "Secret token for APM Server. Managed intake service doesn't support secret token")
 	cmd.Flags().StringVar(&options.APIKey, "api-key", "", "API key to use for authentication")
-	cmd.Flags().StringVar(&options.Loglevel, "log-level", "info", "Specify the log level to use when running this command. Supported values: debug, info, warn, error")
+	cmd.Flags().StringVar(&options.Loglevel, "log-level", "debug", "Specify the log level to use when running this command. Supported values: debug, info, warn, error")
 	cmd.Flags().StringVar(&options.Protocol, "protocol", "apm/http", "Specify the protocol to use when sending events. Supported values: apm/http, otlp/http")
 	cmd.Flags().StringVar(&options.Datatype, "data-type", "any", "Specify the data type to use when sending events. Supported values: any, logs, metrics, traces")
 	cmd.Flags().StringVar(&options.EventRate, "event-rate", "0/s", "Must be in the format <number of events>/<time>. <time> is parsed")

--- a/internal/loadgen/eventhandler/apm.go
+++ b/internal/loadgen/eventhandler/apm.go
@@ -56,10 +56,10 @@ func (t *APMTransport) SendEvents(ctx context.Context, r io.Reader, ignoreErrs b
 	req.ContentLength = -1
 	req.Header = t.intakeHeaders
 	req.Host = req.Header.Get("Host")
-	return t.sendEvents(req, r, ignoreErrs)
+	return t.sendEvents(req, ignoreErrs)
 }
 
-func (t *APMTransport) sendEvents(req *http.Request, r io.Reader, ignoreErrs bool) error {
+func (t *APMTransport) sendEvents(req *http.Request, ignoreErrs bool) error {
 	res, err := t.client.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
Updates the default log level to debug and adds two new fields to the events written log message:

```json
{
    "log.level": "debug",
    "@timestamp": "2024-11-14T16:45:20.989+0800",
    "log.logger": "handler",
    "message": "wrote events to buffer",
    "bytes.uncompressed": 6624943,
    "bytes.compressed": 615572,
    "ecs.version": "1.6.0"
}
```

This should improve the debuggability of the e2e tests.