### PR TITLE
add telemetrygen public package

### DIFF
--- a/pkg/telemetrygen/config.go
+++ b/pkg/telemetrygen/config.go
@@ -1,19 +1,6 @@
-// licensed to elasticsearch b.v. under one or more contributor
-// license agreements. see the notice file distributed with
-// this work for additional information regarding copyright
-// ownership. elasticsearch b.v. licenses this file to you under
-// the apache license, version 2.0 (the "license"); you may
-// not use this file except in compliance with the license.
-// you may obtain a copy of the license at
-//
-//     http://www.apache.org/licenses/license-2.0
-//
-// unless required by applicable law or agreed to in writing,
-// software distributed under the license is distributed on an
-// "as is" basis, without warranties or conditions of any
-// kind, either express or implied.  see the license for the
-// specific language governing permissions and limitations
-// under the license.
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 package telemetrygen
 

--- a/pkg/telemetrygen/doc.go
+++ b/pkg/telemetrygen/doc.go
@@ -1,0 +1,23 @@
+// licensed to elasticsearch b.v. under one or more contributor
+// license agreements. see the notice file distributed with
+// this work for additional information regarding copyright
+// ownership. elasticsearch b.v. licenses this file to you under
+// the apache license, version 2.0 (the "license"); you may
+// not use this file except in compliance with the license.
+// you may obtain a copy of the license at
+//
+//     http://www.apache.org/licenses/license-2.0
+//
+// unless required by applicable law or agreed to in writing,
+// software distributed under the license is distributed on an
+// "as is" basis, without warranties or conditions of any
+// kind, either express or implied.  see the license for the
+// specific language governing permissions and limitations
+// under the license.
+
+// telemetrygen package provides an easy way to generate
+// dummy APM events from a corpus of canned events.
+// Is a public package that is expected to be used outside
+// of this module, as such backward compatibility rules
+// apply.
+package telemetrygen

--- a/pkg/telemetrygen/doc.go
+++ b/pkg/telemetrygen/doc.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the license.
 
-// telemetrygen package provides an easy way to generate
+// Package telemetrygen provides an easy way to generate
 // dummy APM events from a corpus of canned events.
 // Is a public package that is expected to be used outside
 // of this module, as such backward compatibility rules

--- a/pkg/telemetrygen/doc.go
+++ b/pkg/telemetrygen/doc.go
@@ -1,19 +1,6 @@
-// licensed to elasticsearch b.v. under one or more contributor
-// license agreements. see the notice file distributed with
-// this work for additional information regarding copyright
-// ownership. elasticsearch b.v. licenses this file to you under
-// the apache license, version 2.0 (the "license"); you may
-// not use this file except in compliance with the license.
-// you may obtain a copy of the license at
-//
-//     http://www.apache.org/licenses/license-2.0
-//
-// unless required by applicable law or agreed to in writing,
-// software distributed under the license is distributed on an
-// "as is" basis, without warranties or conditions of any
-// kind, either express or implied.  see the license for the
-// specific language governing permissions and limitations
-// under the license.
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
 
 // Package telemetrygen provides an easy way to generate
 // dummy APM events from a corpus of canned events.

--- a/pkg/telemetrygen/generator.go
+++ b/pkg/telemetrygen/generator.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package telemetrygen
 
 import (
@@ -7,8 +11,9 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/elastic/apm-perf/internal/loadgen"
 	"go.uber.org/zap"
+
+	"github.com/elastic/apm-perf/internal/loadgen"
 
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"

--- a/pkg/telemetrygen/generator.go
+++ b/pkg/telemetrygen/generator.go
@@ -1,0 +1,81 @@
+package telemetrygen
+
+import (
+	"context"
+	cryptorand "crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+
+	"github.com/elastic/apm-perf/internal/loadgen"
+	"go.uber.org/zap"
+
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/time/rate"
+)
+
+type Generator struct {
+	Config Config
+	Logger *zap.Logger
+}
+
+func New(cfg Config) (*Generator, error) {
+	if err := cfg.Validate(); err != nil {
+		return &Generator{}, fmt.Errorf("cannot create generator, configuration is invalid: %w", err)
+	}
+
+	return &Generator{Config: cfg, Logger: zap.NewNop()}, nil
+}
+
+func (g *Generator) RunBlocking(ctx context.Context) error {
+	limiter := loadgen.GetNewLimiter(g.Config.EventRate.Burst, g.Config.EventRate.Interval)
+	errg, gCtx := errgroup.WithContext(ctx)
+
+	var rngseed int64
+	err := binary.Read(cryptorand.Reader, binary.LittleEndian, &rngseed)
+	if err != nil {
+		return fmt.Errorf("failed to generate seed for math/rand: %w", err)
+	}
+
+	for i := 0; i < g.Config.AgentReplicas; i++ {
+		for _, expr := range []string{`apm-go*.ndjson`, `apm-nodejs*.ndjson`, `apm-python*.ndjson`, `apm-ruby*.ndjson`} {
+			expr := expr
+			errg.Go(func() error {
+				rng := rand.New(rand.NewSource(rngseed))
+				return runAgent(gCtx, g.Logger, expr, limiter, rng, g.Config)
+			})
+		}
+	}
+
+	return errg.Wait()
+}
+
+func runAgent(ctx context.Context, l *zap.Logger, expr string, limiter *rate.Limiter, rng *rand.Rand, cfg Config) error {
+	handler, err := loadgen.NewEventHandler(loadgen.EventHandlerParams{
+		Logger:                    l,
+		URL:                       cfg.ServerURL.String(),
+		Path:                      expr,
+		APIKey:                    cfg.APIKey,
+		Limiter:                   limiter,
+		Rand:                      rng,
+		RewriteIDs:                cfg.RewriteIDs,
+		RewriteServiceNames:       cfg.RewriteServiceNames,
+		RewriteServiceNodeNames:   cfg.RewriteServiceNodeNames,
+		RewriteServiceTargetNames: cfg.RewriteServiceTargetNames,
+		RewriteSpanNames:          cfg.RewriteSpanNames,
+		RewriteTransactionNames:   cfg.RewriteTransactionNames,
+		RewriteTransactionTypes:   cfg.RewriteTransactionTypes,
+		RewriteTimestamps:         cfg.RewriteTimestamps,
+		Headers:                   cfg.Headers,
+		Protocol:                  "apm/http",
+	})
+	if err != nil {
+		return err
+	}
+
+	if _, err := handler.SendBatches(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/telemetrygen/generator_test.go
+++ b/pkg/telemetrygen/generator_test.go
@@ -1,0 +1,57 @@
+package telemetrygen_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/elastic/apm-perf/pkg/telemetrygen"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneration(t *testing.T) {
+	srv, m := newTestServer(t, testServerConfig{http.StatusServiceUnavailable})
+
+	cfg := telemetrygen.DefaultConfig()
+	cfg.Secure = false
+
+	u, err := url.Parse(srv.URL)
+	cfg.ServerURL = u
+
+	cfg.EventRate.Set("1000/s")
+	g, err := telemetrygen.New(cfg)
+	// g.Logger = zap.Must(zap.NewDevelopment())
+	require.NoError(t, err)
+
+	err = g.RunBlocking(context.Background())
+	require.NoError(t, err)
+	require.Greater(t, m.Load(), int32(0))
+}
+
+type testServerConfig struct {
+	responseStatus int
+}
+type metrics struct {
+	Received *atomic.Int32
+}
+
+func newTestServer(t *testing.T, cfg testServerConfig) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	requestsReceived := &atomic.Int32{}
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		requestsReceived.Add(1)
+		w.Write([]byte("ok"))
+		return
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return srv, requestsReceived
+}

--- a/pkg/telemetrygen/generator_test.go
+++ b/pkg/telemetrygen/generator_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
 package telemetrygen_test
 
 import (
@@ -8,8 +12,9 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/elastic/apm-perf/pkg/telemetrygen"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-perf/pkg/telemetrygen"
 )
 
 func TestGeneration(t *testing.T) {

--- a/pkg/telemetrygen/generator_test.go
+++ b/pkg/telemetrygen/generator_test.go
@@ -13,12 +13,13 @@ import (
 )
 
 func TestGeneration(t *testing.T) {
-	srv, m := newTestServer(t, testServerConfig{http.StatusServiceUnavailable})
+	srv, m := newTestServer(t)
 
 	cfg := telemetrygen.DefaultConfig()
 	cfg.Secure = false
 
 	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
 	cfg.ServerURL = u
 
 	cfg.EventRate.Set("1000/s")
@@ -31,14 +32,7 @@ func TestGeneration(t *testing.T) {
 	require.Greater(t, m.Load(), int32(0))
 }
 
-type testServerConfig struct {
-	responseStatus int
-}
-type metrics struct {
-	Received *atomic.Int32
-}
-
-func newTestServer(t *testing.T, cfg testServerConfig) (*httptest.Server, *atomic.Int32) {
+func newTestServer(t *testing.T) (*httptest.Server, *atomic.Int32) {
 	t.Helper()
 
 	mux := http.NewServeMux()
@@ -47,7 +41,6 @@ func newTestServer(t *testing.T, cfg testServerConfig) (*httptest.Server, *atomi
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		requestsReceived.Add(1)
 		w.Write([]byte("ok"))
-		return
 	})
 
 	srv := httptest.NewServer(mux)


### PR DESCRIPTION
Create a public `telemetrygen` package that can be reused outside of this module.

Up to this point we only leveraged CLI commands available in this module directly from the CLI. 

I wanted to use load generation for https://github.com/elastic/apm-server/issues/14100, but the old `loadgen` package that was imported in this module has been made private (I wasn't able to pinpoint why but I would expect for lack necessity).

Introducing a public package to act as a shallow layer on top of the internals of this module would allow re-using the logic directly in Go.
