### PR TITLE
Fix typo in agent_replicas

### DIFF
--- a/cmd/apmsoak/scenarios_test.yml
+++ b/cmd/apmsoak/scenarios_test.yml
@@ -5,13 +5,13 @@ scenarios:
   apm-server:
     - event_rate: 10/1s
       agent_name: go
-      agents-replicas: 3
+      agent_replicas: 3
     - event_rate: 10/1s
       agent_name: nodejs
-      agents-replicas: 3
+      agent_replicas: 3
     - event_rate: 10/1s
       agent_name: python
-      agents-replicas: 3
+      agent_replicas: 3
     - event_rate: 10/1s
       agent_name: ruby
-      agents-replicas: 3
+      agent_replicas: 3


### PR DESCRIPTION
Correcting a typo to avoid confusion. But not sure how is scenarios_test.yml used.
