### PR TITLE
fix: loadgen references

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -51,7 +51,7 @@ WORKDIR /opt/apm-perf
 
 # Copy files for apmsoak
 COPY --from=builder /opt/apm-perf/dist/apmsoak /usr/bin/apmsoak
-COPY ./internal/loadgen/events ./events
+COPY ./loadgen/events ./events
 COPY ./cmd/apmsoak/scenarios.yml /opt/apm-perf/scenarios.yml
 
 # Copy files for apmbench

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ All the flags are optional, but it's expected to provide a scenario flag to star
 ./apmsoak run --scenario=steady
 ```
 
-The configs in `scenarios.yml` file inherits [loadgen](./internal/loadgen/config/config.go) configs, with extra fields such as project_id and api_key that can be used for the managed APM service.
+The configs in `scenarios.yml` file inherits [loadgen](./loadgen/config/config.go) configs, with extra fields such as project_id and api_key that can be used for the managed APM service.
 
 Note that the managed service will use API key based auth and one soaktest can target multiple projects, so we provide key-value pairs(projectID and api key respectively). the api key can also be provided as an [ENV variable](https://github.com/elastic/apm-perf/blob/main/cmd/apmsoak/run.go#L20).
 


### PR DESCRIPTION
Fix `loadgen` references after it has been moved from `./internal/loadgen` to `./loadgen` by https://github.com/elastic/apm-perf/pull/222.