### PR TITLE
apmtelemetrygen: use appropriate exit codes

### DIFF
--- a/cmd/apmtelemetrygen/main.go
+++ b/cmd/apmtelemetrygen/main.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"math/rand"
 	"os"
 	"os/signal"
@@ -70,9 +71,11 @@ func main() {
 	// Execute commands
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		if !errors.Is(err, context.Canceled) {
-			fmt.Println(err)
+			log.Fatal(err)
 		}
+		os.Exit(130) // Signal CTRL-C exit
 	}
+	os.Exit(0)
 }
 
 type headersFlag map[string]string


### PR DESCRIPTION
Upon execution exit apmtelemetrygen with the appropriate exit codes.

Exit 1 for any unexpected error.
Exit 130 for interruption via SIGINT or SIGTERM.
Exit 0 on success.

Exit code for interrupt taken from https://tldp.org/LDP/abs/html/exitcodes.html#EXITCODESREF

This fix originated from investigating this bug report https://github.com/elastic/apm-managed-service/issues/1761
