### PR TITLE
ci: group dependabot otel bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
       otel:
         patterns:
         - "go.opentelemetry.io/*"
+        - "github.com/open-telemetry/*"
       spf13:
         patterns:
         - "github.com/spf13/*"
@@ -32,6 +33,7 @@ updates:
       otel:
         patterns:
         - "go.opentelemetry.io/*"
+        - "github.com/open-telemetry/*"
       golang.org/x/:
         patterns:
         - "golang.org/x/*"


### PR DESCRIPTION
Add github.com/open‑telemetry/* to the otel dependency group

Both the GitHub URL and the domain‑based import paths are used for OpenTelemetry dependencies. Grouping them together prevents duplicate pull requests and reduces unnecessary noise.